### PR TITLE
修复'_config.yml'中'excerpt_link'配置不起作用的问题

### DIFF
--- a/layout/_partial/simple_article.ejs
+++ b/layout/_partial/simple_article.ejs
@@ -17,7 +17,9 @@
 
         <% if (item.excerpt) { %>
         <div class="card-action <%= theme.color.link %>-link-context">
-            <a href="<%= "/" + item.path %>">READ MORE</a>
+            <a href="<%= "/" + item.path %>"> 
+                <%= theme.excerpt_link %> 
+            </a>
         </ div>
         <% } %>
     </div>


### PR DESCRIPTION
刚刚开始使用hexo搭建博客，非常喜欢这款主题，首先感谢您。我在试图把Read More改成阅读更多时，发现这个配置不能使用，希望这款主题能变得更好。